### PR TITLE
Forgot to modify this one!

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include README.txt
+include README.md
 include LICENSE
 include ncml/*.py


### PR DESCRIPTION
It is good practice to have a markdown `README.md` for github and a rst `README.txt` for PyPI.  You can create that with `pandoc --from markdown_github README.md --to rst --output README.txt`.

Here I am just fixing the file extension in the `MANIFEST.in`.
